### PR TITLE
Fix horizontal jumpings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -443,13 +443,13 @@ export default class extends Component {
         if (this.state.index === 0) {
           this.props.horizontal
             ? this.scrollView.scrollTo({
-                x: state.width,
+                x: 0,
                 y: 0,
                 animated: false
               })
             : this.scrollView.scrollTo({
                 x: 0,
-                y: state.height,
+                y: 0,
                 animated: false
               })
         } else if (this.state.index === this.state.total - 1) {

--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ export default class extends Component {
         {...this.props}
         {...this.scrollViewPropOverrides()}
         contentContainerStyle={[styles.wrapperIOS, this.props.style]}
-        contentOffset={this.state.offset}
+        //contentOffset={this.state.offset}
         onScrollBeginDrag={this.onScrollBegin}
         onMomentumScrollEnd={this.onScrollEnd}
         onScrollEndDrag={this.onScrollEndDrag}


### PR DESCRIPTION
### Is it a bugfix ?
- Yes 
- #1033 

### Is it a new feature ?
- No

### Describe what you've done:
Removed the contentOffset from ScrollView as it does something on iOS (but not on Android), when you touch a Touchable in a card contained in the Swiper. It was jumping around a bit, because the offset was wrongly calulated. As the library nowadays only uses scrolling to go through pages, it is ok to abandon (i hope). Maybe this breaks other features, I currently don't use!


### How to test it ?
